### PR TITLE
Make the first paragraph of Section 7 only three lines long

### DIFF
--- a/tb139starynovotny-testing.ltx
+++ b/tb139starynovotny-testing.ltx
@@ -383,7 +383,7 @@ We ran the experiments for 33 days on a shared \GNU/Linux server with 400~\acro{
 \section{Results}
 \label{sec:results}
 
-Figure~\ref{fig:results} shows the results of our experiments. In this section, we discuss the results and how they relate to the three research questions outlined in the previous section.
+Figure~\ref{fig:results} shows the results of our experiments. In this section, we discuss the results and how they relate to the three research questions from previous section.
 
 \subsection{Multiprocessing}
 With batch size 1, the testing speed scales almost linearly with the number of \acro{CPU}s, as we would expect: Whereas with 1~\acro{CPU}, the median testing time is 27~hours and 2~minutes, it is only 1~hour and 6~minutes with 32~\acro{CPU}s (about 24-fold speed-up).\footnote{%


### PR DESCRIPTION
This PR makes the first paragraph of Section 7 only three lines long. Previously, it spanned four lines, which looked odd:

![image](https://github.com/Witiko/fast-regression-testing/assets/603082/6150c8d5-f72e-439b-8bbe-193403e8d730)

Alternatively, we may want to increase the vertical space above Figure 1.