### PR TITLE
Do not break line between "12" and "CPUs"

### DIFF
--- a/tb139starynovotny-testing.ltx
+++ b/tb139starynovotny-testing.ltx
@@ -470,7 +470,7 @@ of the Markdown package for \TeX.
 
 We graciously invite donations of GitHub self-hosted runners,
 particularly those hosted on \acro{GNU}\slash Linux servers with at
-least 16 \acro{GB} of \acro{RAM} and 12 \acro{CPU}s. For more
+least 16 \acro{GB} of \acro{RAM} and 12~\acro{CPU}s. For more
 information, please contact us by email. Donors will be acknowledged in
 the project documentation, with the option to remain anonymous upon
 request.


### PR DESCRIPTION
This PR prohibits a line break between "12" and "CPUs" in section "Donation request". This improves readability.